### PR TITLE
Default styles for images

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,10 @@
 Wir betreiben nur den Ilaris-Fork des eigentlich englischsprachigen, auf DnD ausgelegten [Homebrewery Projekts](https://homebrewery.naturalcrit.com). Gelegentlich holen wir uns auch einige neue Features, die dort entwickelt werden. Hier gehts zum [Changelog des Hauptprojekts](https://homebrewery.naturalcrit.com/changelog)
 ::
 
+### V0.2
+- Default für Bilder: Zeilenbreite und blend-mode: multiply
+- Vollbild Klasse, zB für A4 Hintergrundbilder
+
 ### V0.1
 ##### Layout
 - Eigenes Design, etwas schlichter als das Regelwerk

--- a/themes/V3/Ilaris/snippets.js
+++ b/themes/V3/Ilaris/snippets.js
@@ -592,8 +592,7 @@ module.exports = [
 					return dedent`
 						\page
 						{{kopfzeile Karten}}
-						{{karten}}
-						{{keinhintergrund}}
+						{{karten,keinhintergrund}}
 			
 						{{karte,schwarz
 						#### Randfarben
@@ -657,7 +656,7 @@ module.exports = [
 						Text...
 						
 						##### Tabelle auf Karte
-						| Spezies | Hintergrund | Fähigkeiten |
+						| Spezies | Rolle | Fähigkeiten |
 						|:------------------|:-----:|:-----------------:|
 						| Menschen                 | Krieger     | Schwertkampf, Taktik, Ausdauer                |
 						| Elfen               | Magier     | Elementarmagie, Heilung, Illusion                |

--- a/themes/V3/Ilaris/snippets/coverpage.gen.js
+++ b/themes/V3/Ilaris/snippets/coverpage.gen.js
@@ -107,7 +107,7 @@ module.exports = {
 		  # ${_.sample(titles)}
 		  ## ${_.sample(subtitles)}
 
-		  ![Hintergrund](/assets/ilaris/hintergruende/challenger.png){position:absolute,bottom:0,left:0,width:100%,height:100%}
+		  {{vollbild ![Hintergrund](/assets/ilaris/hintergruende/challenger.png)}}
 
 		  {{fusszeile 
 		    Ilaris - Schlanke Regeln für Aventurien
@@ -201,11 +201,11 @@ module.exports = {
 			{{wide,width:50%,position:absolute,bottom:10px,left:1.5cm
 			##### Auf einen Blick
 			| | | | | |
-			|:-----|:-:|:-:|:-:|:-:|
+			|:----------------------|:--:|:--:|:--:|:--:|
 			| Genre                 | Attentat, Rätsel ||||
-			| Ort                 | Beliebig ||||
-			| Zeit                 | Beliebig ||||
-			| Benötigt                 | Ilaris GRW ||||
+			| Ort                   | Beliebig ||||
+			| Zeit                  | Beliebig ||||
+			| Benötigt              | Ilaris GRW ||||
 			| Komplexität Spieler   | {{punkt,voll}} | {{punkt,leer}} | {{punkt,leer}} | {{punkt,leer}} |
 			| Komplexität Meister   | {{punkt,voll}} | {{punkt,voll}} | {{punkt,leer}} | {{punkt,leer}} |
 			| Erfahrungsgrad        | {{punkt,voll}} | {{punkt,voll}} | {{punkt,voll}} | {{punkt,leer}} |

--- a/themes/V3/Ilaris/style.less
+++ b/themes/V3/Ilaris/style.less
@@ -212,7 +212,12 @@ body {
 	}
 
 	img {
-		z-index: -1;
+		z-index: -1;    
+		display: block;
+		width: 100%;
+		margin-left: auto;
+		margin-right: auto;
+		mix-blend-mode: multiply;
 	}
 
 	strong {
@@ -1522,6 +1527,18 @@ body {
 
 		img {
 			height: 3cm;
+			width: auto;
+		}
+	}
+
+	.vollbild {
+		img {
+			position: absolute;
+			bottom: 0;
+			left: 0;
+			width: 100%;
+			height: 100%;
+			mix-blend-mode: unset;
 		}
 	}
 }

--- a/themes/V3/Ilaris/style.less
+++ b/themes/V3/Ilaris/style.less
@@ -377,61 +377,61 @@ body {
 		display: inline-block;
 		width: 1em;
 		height: 1em;
-		// background-image: url(/assets/ilaris/icons/chess-pawn.svg);
+		// background-image: url(/assets/ilaris/game_icons/chess-pawn.svg);
 		// filter: brightness(0.5) sepia(1) hue-rotate(-70deg) saturate(5);
 		-webkit-mask-size: cover;
 		mask-size: cover;
 		background-color: black;
-		-webkit-mask: url(/assets/ilaris/icons/chess-pawn.svg) no-repeat 100% 100%;
-		mask: url(/assets/ilaris/icons/chess-pawn.svg) no-repeat 100% 100%;
+		-webkit-mask: url(/assets/ilaris/game_icons/chess-pawn.svg) no-repeat 100% 100%;
+		mask: url(/assets/ilaris/game_icons/chess-pawn.svg) no-repeat 100% 100%;
 
 	}
 
 	.symbol.koenig,
 	.symbol.koenigin,
 	.symbol.queen {
-		-webkit-mask: url(/assets/ilaris/icons/chess-queen.svg) no-repeat 100% 100%;
-		// mask: url(/assets/ilaris/icons/chess-queen.svg) no-repeat 100% 100%;
+		-webkit-mask: url(/assets/ilaris/game_icons/chess-queen.svg) no-repeat 100% 100%;
+		// mask: url(/assets/ilaris/game_icons/chess-queen.svg) no-repeat 100% 100%;
 	}
 
 	.symbol.springer,
 	.symbol.pferd,
 	.symbol.knight {
-		-webkit-mask: url(/assets/ilaris/icons/chess-knight.svg) no-repeat 100% 100%;
+		-webkit-mask: url(/assets/ilaris/game_icons/chess-knight.svg) no-repeat 100% 100%;
 	}
 
 	.symbol.bauer {
-		-webkit-mask: url(/assets/ilaris/icons/chess-pawn.svg) no-repeat 100% 100%;
+		-webkit-mask: url(/assets/ilaris/game_icons/chess-pawn.svg) no-repeat 100% 100%;
 	}
 
 	.symbol.leicht,
 	.symbol.feder {
-		-webkit-mask: url(/assets/ilaris/icons/feather.svg) no-repeat 100% 100%;
+		-webkit-mask: url(/assets/ilaris/game_icons/feather.svg) no-repeat 100% 100%;
 	}
 
 	.symbol.schwer,
 	.symbol.medalie {
-		-webkit-mask: url(/assets/ilaris/icons/medal-skull.svg) no-repeat 100% 100%;
+		-webkit-mask: url(/assets/ilaris/game_icons/medal-skull.svg) no-repeat 100% 100%;
 	}
 
 	.symbol.helm {
-		-webkit-mask: url(/assets/ilaris/icons/warlord-helmet.svg) no-repeat 100% 100%;
+		-webkit-mask: url(/assets/ilaris/game_icons/warlord-helmet.svg) no-repeat 100% 100%;
 	}
 
 	.symbol.schubkarre {
-		-webkit-mask: url(/assets/ilaris/icons/wheelbarrow.svg) no-repeat 100% 100%;
+		-webkit-mask: url(/assets/ilaris/game_icons/wheelbarrow.svg) no-repeat 100% 100%;
 	}
 
 	.symbol.kompass {
-		-webkit-mask: url(/assets/ilaris/icons/compass.svg) no-repeat 100% 100%;
+		-webkit-mask: url(/assets/ilaris/game_icons/compass.svg) no-repeat 100% 100%;
 	}
 
 	.symbol.schatz {
-		-webkit-mask: url(/assets/ilaris/icons/open-treasure-chest.svg) no-repeat 100% 100%;
+		-webkit-mask: url(/assets/ilaris/game_icons/open-treasure-chest.svg) no-repeat 100% 100%;
 	}
 
 	.symbol.turm {
-		-webkit-mask: url(/assets/ilaris/icons/locked-fortress.svg) no-repeat 100% 100%;
+		-webkit-mask: url(/assets/ilaris/game_icons/locked-fortress.svg) no-repeat 100% 100%;
 	}
 
 	.symbol.gruen {


### PR DESCRIPTION
<img> is per default displayed as block, with blend-mode-multiply. 
logo and vollbild classes are adjusted to overwrite this options.

symbols and karten snippets are fixed on the fly